### PR TITLE
Add Node types dev dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ MoneyPrinterBot is designed for seamless integration into any Node.js/TypeScript
 
 ```
 npm install @solana/web3.js bs58 axios node-fetch zod
+npm install --save-dev typescript @types/node
 ```
 
 ### 2. Project Structure

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "zod": "^3.22.4"
   },
   "devDependencies": {
-    "typescript": "^5.0.0"
+    "typescript": "^5.0.0",
+    "@types/node": "^20"
   }
 }


### PR DESCRIPTION
## Summary
- include `@types/node` in `devDependencies`
- document dev dependencies in installation instructions

## Testing
- `npm run build` *(fails: Cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_688021c608048322a36c47759e4f496a