### PR TITLE
Fix SessionManager initialization

### DIFF
--- a/MoneyPrinterBot.ts
+++ b/MoneyPrinterBot.ts
@@ -33,7 +33,7 @@ export class MoneyPrinterBot extends EventEmitter {
     this.classifier = new Classifier(this.settings);
     this.trader = new Trader(this.settings);
     this.risk = new RiskManager(this.settings);
-    this.session = new SessionManager(this.settings);
+    this.session = new SessionManager(this.settings, this.trader);
     if (onTrade) this.trader.on('trade', onTrade);
     if (onError) this.on('error', onError);
     // Wire up event flow

--- a/server.ts
+++ b/server.ts
@@ -23,7 +23,7 @@ const watcher = new Watcher(settings);
 const classifier = new Classifier(settings);
 const trader = new Trader(settings);
 const risk = new RiskManager(settings);
-const session = new SessionManager(settings);
+const session = new SessionManager(settings, trader);
 
 let botActive = false;
 


### PR DESCRIPTION
## Summary
- connect Trader to SessionManager in MoneyPrinterBot
- connect Trader to SessionManager in server

## Testing
- `npm run build` *(fails: cannot find module 'events' etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688021c768d0832288663987aaf2cea8