### PR TITLE
Fix README server command and add TypeScript note

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ MoneyPrinterBot is designed for seamless integration into any Node.js/TypeScript
 ```
 npm install @solana/web3.js bs58 axios node-fetch zod
 ```
+TypeScript users must also install `@types/node`.
 
 ### 2. Project Structure
 - Place all core files (`Trader`, `Watcher`, `Classifier`, `Risk`, `Session`, `Settings`, `moneyPrinterBot.ts`) in your backend project directory.
@@ -308,6 +309,7 @@ All settings are in `settings.json` (see `settings.example.json`):
    ```bash
    npm install
    ```
+   *Note: `@types/node` must also be installed for TypeScript builds.*
 2. **Configure settings:**
    - Copy `settings.example.json` to `settings.json` and fill in your values.
 3. **(Optional) Set up Supabase:**
@@ -315,7 +317,7 @@ All settings are in `settings.json` (see `settings.example.json`):
    - Add your Supabase URL and Key to `settings.json`
 4. **Run the server:**
    ```bash
-   npx ts-node api/server.ts
+   npx ts-node server.ts
    ```
    The server will start on port 3000 by default.
 


### PR DESCRIPTION
## Summary
- note that `@types/node` is needed for TypeScript builds
- fix server startup command in README

## Testing
- `npm run build` *(fails: Cannot find module 'path' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_688021c9478c83229765d9996cc56893