### PR TITLE
Fix config path in server.ts

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -15,7 +15,10 @@ const server = http.createServer(app);
 const wss = new WebSocketServer({ server });
 
 // Load and validate settings
-const settingsPath = path.resolve(process.cwd(), 'settings.example.json'); // Change to actual settings.json in prod
+// Allow overriding the settings file via the SETTINGS_PATH env var
+const settingsPath = process.env.SETTINGS_PATH
+  ? path.resolve(process.cwd(), process.env.SETTINGS_PATH)
+  : path.resolve(process.cwd(), 'settings.json');
 const settings = loadSettings(settingsPath);
 
 // Instantiate core modules


### PR DESCRIPTION
## Summary
- allow configuring settings path via `SETTINGS_PATH`
- default to `settings.json`

## Testing
- `npx tsc` *(fails: Cannot find module 'events', '@solana/web3.js', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_688021c8353c8322bd4ec3b7bd3d2e28