### PR TITLE
Fix README support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,10 +388,3 @@ All settings are in `settings.json` (see `settings.example.json`):
 
 ## Support
 For questions or help, open an issue or contact the project maintainer.
-# MoneyPrinterSolSnipingBot
-MoneyPrinterSolSnipingBot
-
-## Support
-For questions or help, open an issue or contact the project maintainer.
-# MoneyPrinterSolSnipingBot
-MoneyPrinterSolSnipingBot


### PR DESCRIPTION
## Summary
- remove duplicate lines at the end of README so it ends with one clean Support section

## Testing
- `tail -n 5 README.md`


------
https://chatgpt.com/codex/tasks/task_e_6880261942d4832293e82bfa03b515cb